### PR TITLE
chore: add semantic-release CI + update outdated package.json

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,28 @@
+name: master
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm run build
+      - uses: cycjimmy/semantic-release-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.REPO_READ_TOKEN }}
+        with:
+          semantic_version: 17.3.7
+          extra_plugins: |
+            @semantic-release/changelog@5.0.1
+            @semantic-release/git@9.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: d2c actions
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   test:

--- a/package.json
+++ b/package.json
@@ -1,16 +1,13 @@
 {
   "name": "@d2c-actions/buildinfo",
-  "version": "1.0.0",
+  "version": "5.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {
     "build": "ncc build index.js -o .dist"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/take-two/d2c-actions.git"
-  },
-  "author": "",
+  "repository": "github:russel-yang/buildinfo-actions",
+  "author": "Take-Two Interactive, Inc.",
   "license": "ISC",
   "dependencies": {
     "@actions/core": "1.2.6",
@@ -21,10 +18,6 @@
   "devDependencies": {
     "@vercel/ncc": "^0.24.1"
   },
-  "bugs": {
-    "url": "https://github.com/take-two/d2c-actions/issues"
-  },
-  "homepage": "https://github.com/take-two/d2c-actions#readme"
   "release": {
     "plugins": [
       "@semantic-release/commit-analyzer",

--- a/package.json
+++ b/package.json
@@ -25,4 +25,29 @@
     "url": "https://github.com/take-two/d2c-actions/issues"
   },
   "homepage": "https://github.com/take-two/d2c-actions#readme"
+  "release": {
+    "plugins": [
+      "@semantic-release/commit-analyzer",
+      "@semantic-release/release-notes-generator",
+      "@semantic-release/changelog",
+      [
+        "@semantic-release/npm",
+        {
+          "npmPublish": false
+        }
+      ],
+      "@semantic-release/github",
+      [
+        "@semantic-release/git",
+        {
+          "assets": [
+            ".dist/**/*",
+            "CHANGELOG.md",
+            "package.json",
+            "package-lock.json"
+          ]
+        }
+      ]
+    ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": "github:russel-yang/buildinfo-actions",
   "author": "Take-Two Interactive, Inc.",
-  "license": "ISC",
+  "license": "UNLICENSED",
   "dependencies": {
     "@actions/core": "1.2.6",
     "@actions/github": "2.0.0",


### PR DESCRIPTION
note: `REPO_READ_TOKEN` (a github PAT with public repo read access) needs to be added to secrets for this to work